### PR TITLE
Process AsciiDoc tab blocks for Unix-only ingestion

### DIFF
--- a/tests/test_ingest_adoc.py
+++ b/tests/test_ingest_adoc.py
@@ -18,3 +18,42 @@ def test_load_documents_only_adoc(tmp_path):
 
     assert len(documents) == 1
     assert documents[0].metadata.get("source", "").endswith("sample.adoc")
+
+
+def test_preprocess_tabs_content_unix_only():
+    from scripts.ingest_adoc import preprocess_tabs_content
+
+    raw_content = """Intro text
+[tabs]
+====
+tab:Unix[]
+--
+[source,bash]
+----
+echo 'hello'
+----
+--
+tab:Unix[]
+--
+[source,bash]
+----
+echo 'hello'
+----
+--
+tab:Windows[]
+--
+dir
+--
+====
+Outro text
+"""
+
+    expected = """Intro text
+[source,bash]
+----
+echo 'hello'
+----
+Outro text
+"""
+
+    assert preprocess_tabs_content(raw_content) == expected


### PR DESCRIPTION
## Summary
- add a preprocess_tabs_content helper that collapses Antora tab blocks to deduplicated Unix-only bodies
- run the helper on documents loaded in ingest_adoc so downstream splitting receives cleaned content
- add a regression test covering the Unix-only rendering of a tabs example

## Testing
- pytest tests/test_ingest_adoc.py

------
https://chatgpt.com/codex/tasks/task_e_68db560939ec833196a4a9c7127cf489