### PR TITLE
Configure logging format and silence httpx noise

### DIFF
--- a/main.py
+++ b/main.py
@@ -152,7 +152,11 @@ def build_application(token: str) -> Application:
 def main() -> None:
     """Run the Telegram bot backed by the Ollama RAG pipeline."""
 
-    logging.basicConfig(level=logging.INFO)
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+    logging.getLogger("httpx").setLevel(logging.WARNING)
 
     token = os.getenv("TELEGRAM_TOKEN")
     if not token:


### PR DESCRIPTION
## Summary
- configure the Telegram bot entry point to use a structured logging format
- lower the verbosity of the httpx logger to suppress noisy output during runtime

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db60953df88331a054e1d035d93cb4