### PR TITLE
Handle Ollama query timeouts asynchronously

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -41,3 +41,56 @@ def test_handle_text_triggers_typing_indicator(monkeypatch):
         ((), {"action": main.ChatAction.TYPING, "chat_id": 42, "bot": context.bot})
     ]
     message.reply_text.assert_awaited_once_with("response")
+
+
+def test_handle_text_timeout_sends_notice_and_recovers(monkeypatch):
+    """The bot should notify the user on timeout and continue serving new messages."""
+
+    monkeypatch.setenv(main.OLLAMA_TIMEOUT_ENV, "0.01")
+    monkeypatch.setattr(main, "ChatActionSender", None)
+
+    async def slow_action(func, *args, **kwargs):
+        try:
+            await asyncio.sleep(0.05)
+        except asyncio.CancelledError:
+            raise
+        return func(*args, **kwargs)
+
+    async def fast_action(func, *args, **kwargs):
+        return func(*args, **kwargs)
+
+    actions = [slow_action, fast_action]
+
+    async def fake_to_thread(func, *args, **kwargs):
+        if actions:
+            action = actions.pop(0)
+        else:  # pragma: no cover - defensive fallback
+            action = fast_action
+        return await action(func, *args, **kwargs)
+
+    monkeypatch.setattr(main.asyncio, "to_thread", fake_to_thread)
+
+    query_calls = []
+
+    def fake_query(message, session_id):
+        query_calls.append((message.question, session_id))
+        return "resolved response"
+
+    monkeypatch.setattr(main.ollama, "query_rag", fake_query)
+
+    first_message = SimpleNamespace(text="first", reply_text=AsyncMock())
+    second_message = SimpleNamespace(text="second", reply_text=AsyncMock())
+
+    chat = SimpleNamespace(id=7)
+    bot = SimpleNamespace(send_chat_action=AsyncMock())
+    context = SimpleNamespace(bot=bot)
+
+    asyncio.run(main.handle_text(SimpleNamespace(message=first_message, effective_chat=chat), context))
+    asyncio.run(main.handle_text(SimpleNamespace(message=second_message, effective_chat=chat), context))
+
+    first_message.reply_text.assert_awaited_once_with(
+        "Sorry, the request timed out before I could reply. Please try again later."
+    )
+    second_message.reply_text.assert_awaited_once_with("resolved response")
+    assert bot.send_chat_action.await_count == 2
+    assert query_calls == [("second", "7")]


### PR DESCRIPTION
## Summary
- run blocking Ollama RAG queries in a worker thread and honor an optional OLLAMA_TIMEOUT value
- surface timeout responses to users without updating chat history while keeping normal flow intact
- add regression coverage that exercises the timeout path and ensures subsequent messages still work

## Testing
- pytest tests/test_main.py

